### PR TITLE
Read redirect settings from environment

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,10 +6,10 @@ import ThemeConfig from './theme';
 // components
 import ScrollToTop from './components/ScrollToTop';
 
-import awsconfig from './aws-exports';
+import appSettings from './appSettings';
 // ----------------------------------------------------------------------
 
-Amplify.configure(awsconfig);
+Amplify.configure(appSettings);
 
 export default function App() {
   return (

--- a/src/appSettings.js
+++ b/src/appSettings.js
@@ -1,0 +1,12 @@
+import awsconfig from './aws-exports';
+
+const appSettings = {
+  ...awsconfig,
+  oauth: {
+    ...awsconfig.oauth,
+    redirectSignIn: process.env.REACT_APP_REDIRECT_SIGN_IN,
+    redirectSignOut: process.env.REACT_APP_REDIRECT_SIGN_OUT
+  }
+};
+
+export default appSettings;


### PR DESCRIPTION
Fixes #24 

The sign in and sign out redirect URL can be set using the `REACT_APP_REDIRECT_SIGN_IN` and `REACT_APP_REDIRECT_SIGN_OUT` environment variables. Note that the URL must also be added to the Cognito user pool settings.

